### PR TITLE
fix(discovery): fix synchronous discover function

### DIFF
--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -325,12 +325,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
         of nearby devices.
 
     """
-    device = kwargs.get("device", "hci0")
 
-    # Discovery filters
-    filters = kwargs.get("filters", {})
-
-    discovery = AsyncDiscovery(callback=None, loop=loop, device=device)
-    await discovery.start_discovery(filters)
+    disco = await discover_async(None, loop, **kwargs)
     await asyncio.sleep(timeout)
-    return await discovery.stop_discovery()
+    return await disco.stop_discovery()


### PR DESCRIPTION
The discover function was not properly updated during development and
used an old signature. Update it to use the async discovery function
internally.