### PR TITLE
clean(packaging): Rename python package as 'bleak-proglove'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = "bleak"
-DESCRIPTION = "Bluetooth Low Energy platform Agnostic Klient"
+NAME = "bleak-proglove"
+DESCRIPTION = "Bluetooth Low Energy platform Agnostic Klient (ProGlove's fork)"
 URL = "https://github.com/hbldh/bleak"
 EMAIL = "henrik.blidh@nedomkull.com"
 AUTHOR = "Henrik Blidh"
@@ -38,7 +38,7 @@ with io.open(os.path.join(here, "HISTORY.rst"), encoding="utf-8") as f:
 
 # Load the package's __version__.py module as a dictionary.
 about = {}
-with open(os.path.join(here, NAME, "__version__.py")) as f:
+with open(os.path.join(here, "bleak", "__version__.py")) as f:
     exec(f.read(), about)
 
 


### PR DESCRIPTION
This package renaming is to avoid dependency issue with the official 'bleak' python package.
This fork should be refered as 'bleak-proglove'.

The python package is still named 'bleak' in the source code.