### PR TITLE
Various fixes for flake8

### DIFF
--- a/bleak/backends/_manufacturers.py
+++ b/bleak/backends/_manufacturers.py
@@ -1932,5 +1932,8 @@ MANUFACTURERS = {
     0x0786: "HLP Controls Pty Limited",
     0x0787: "Pangaea Solution",
     0x0788: "BubblyNet, LLC",
-    0xFFFF: "This value has special meaning depending on the context in which it used. Link Manager Protocol (LMP): This value may be used in the internal and interoperability tests before a Company ID has been assigned. This value shall not be used in shipping end products. Device ID Profile: This value is reserved as the default vendor ID when no Device ID service record is present in a remote device.",
+    0xFFFF: "This value has special meaning depending on the context in which it used. Link Manager Protocol (LMP): "
+    "This value may be used in the internal and interoperability tests before a Company ID has been assigned. "
+    "This value shall not be used in shipping end products. Device ID Profile: This value is reserved as the "
+    "default vendor ID when no Device ID service record is present in a remote device.",
 }

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -49,7 +49,7 @@ def _device_info(path, props):
                 address = None
         rssi = props.get("RSSI", "?")
         return name, address, rssi, path
-    except Exception as e:
+    except Exception:
         # logger.exception(e, exc_info=True)
         return None, None, None, None
 

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -50,7 +50,6 @@ def _device_info(path, props):
         rssi = props.get("RSSI", "?")
         return name, address, rssi, path
     except Exception:
-        # logger.exception(e, exc_info=True)
         return None, None, None, None
 
 

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -83,7 +83,7 @@ class CentralManagerDelegate(NSObject):
     @property
     def isConnected(self) -> bool:
         # Validate this
-        return self.connected_peripheral != None
+        return self.connected_peripheral is not None
 
     async def is_ready(self):
         """is_ready allows an asynchronous way to wait and ensure the

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -29,8 +29,6 @@ async def discover(
     """
     loop = loop if loop else asyncio.get_event_loop()
 
-    devices = {}
-
     if not cbapp.central_manager_delegate.enabled:
         raise BleakError("Bluetooth device is turned off")
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -141,7 +141,7 @@ class BleakClientDotNet(BaseBleakClient):
         self._requester.ConnectionStatusChanged += _ConnectionStatusChanged_Handler
 
         # Obtain services, which also leads to connection being established.
-        services = await self.get_services()
+        _ = await self.get_services()
         connected = False
         if self._services_resolved:
             # If services has been resolved, then we assume that we are connected. This is due to

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -137,7 +137,7 @@ class BleakClientDotNet(BaseBleakClient):
         self._requester.ConnectionStatusChanged += _ConnectionStatusChanged_Handler
 
         # Obtain services, which also leads to connection being established.
-        _ = await self.get_services()
+        await self.get_services()
         connected = False
         if self._services_resolved:
             # If services has been resolved, then we assume that we are connected. This is due to

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -15,9 +15,7 @@ from bleak.exc import BleakError, BleakDotNetTaskError
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.dotnet.discovery import discover
 from bleak.backends.dotnet.utils import (
-    wrap_Task,
     wrap_IAsyncOperation,
-    IAsyncOperationAwaitable,
 )
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.dotnet.service import BleakGATTServiceDotNet
@@ -40,11 +38,9 @@ from Windows.Devices.Bluetooth import (
     BluetoothAddressType,
 )
 from Windows.Devices.Bluetooth.GenericAttributeProfile import (
-    GattDeviceService,
     GattDeviceServicesResult,
     GattCharacteristic,
     GattCharacteristicsResult,
-    GattDescriptor,
     GattDescriptorsResult,
     GattCommunicationStatus,
     GattReadResult,

--- a/bleak/backends/dotnet/discovery.py
+++ b/bleak/backends/dotnet/discovery.py
@@ -14,7 +14,7 @@ from asyncio.events import AbstractEventLoop
 from bleak.backends.device import BLEDevice
 
 # Import of Bleak CLR->UWP Bridge. It is not needed here, but it enables loading of Windows.Devices
-from BleakBridge import Bridge
+from BleakBridge import Bridge  # noqa: F401 'BleakBridge.Bridge' imported but unused (Ignore for flake8)
 
 from System import Array, Byte
 from Windows.Devices import Enumeration

--- a/bleak/utils.py
+++ b/bleak/utils.py
@@ -25,4 +25,4 @@ def mac_int_2_str(mac):
 
     """
     m = hex(mac)[2:].upper().zfill(12)
-    return ":".join([m[i : i + 2] for i in range(0, 12, 2)])
+    return ":".join([m[i:i + 2] for i in range(0, 12, 2)])

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ universal = 1
 
 [flake8]
 exclude = docs
+max-line-length = 140
 
 [aliases]
 test = pytest


### PR DESCRIPTION
**Context:** I was working on adding 'bleak-proglove' to our CI. I wanted to run the tests recommended by `bleak` maintainers in https://github.com/hbldh/bleak/blob/master/CONTRIBUTING.rst
But `flake8 bleak tests` did not pass.

Here are the fixes to make `flake8 bleak tests` passes.

The intent of this merge request is to be rebased on the latest public `master` to be sent as a public pull-request on the project.