### PR TITLE
fix(client): don't remove resources from shared reactor

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -225,8 +225,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # Stop the Twisted reactor holding the connection to the DBus system.
         try:
-            self._reactor.disconnectAll()
-            self._reactor.removeAll()
             self._reactor.stop()
         except Exception as e:
             # I think Bleak will always end up here, but I want to call stop just in case...


### PR DESCRIPTION
On disconnect, the watchers, readers and writers of the reactor should
not removed entirely, since a different client might use the same
reactor. The reactor would not notify the other clients then.