### PR TITLE
fix(client): Check that the bus is instantiated before accessing it

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -283,6 +283,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             Boolean representing connection status.
 
         """
+        if self._bus is None:
+            return False
+
         # TODO: Listen to connected property changes.
         return await self._bus.callRemote(
             self._device_path,


### PR DESCRIPTION
There are plenty of places where we use the `_bus` variable that could be `None` but this PR only checks the one in `is_connected` 