### PR TITLE
feat(version): Append a development number to the version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import io
 import os
 import sys
 from shutil import rmtree
-
+import subprocess  # nosec
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
@@ -75,10 +75,26 @@ class UploadCommand(Command):
         sys.exit()
 
 
+def _get_extra_dev_string() -> str:
+    git_file_hash = subprocess.check_output([  # nosec
+        'git', 'log', '--follow', '-1', '--pretty=%H',
+        os.path.join(here, "bleak", "__version__.py")]).decode().split('\n')[0]
+
+    num_commits = int(subprocess.check_output([
+        'git', 'rev-list', '--count', git_file_hash+'..HEAD']
+    ).decode().split('\n')[0])
+
+
+    if num_commits > 0:
+        return '.dev%u' % num_commits
+
+    return ''
+
+
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about["__version__"],
+    version=about["__version__"] + _get_extra_dev_string(),
     description=DESCRIPTION,
     long_description=long_description,
     author=AUTHOR,


### PR DESCRIPTION
Append a `.dev.N` to the version number which matches the number of
commit from HEAD to the last commit of the `__version.py` file.
A number of commits equal to 25 will produce the following version:
    x.y.z.dev25
A number of commits equal to zero will produce the following version:
    x.y.z