### PR TITLE
feat(client): Add a method to get the exchanged MTU

### DIFF
--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -8,7 +8,7 @@ Created on 2018-04-23 by hbldh <henrik.blidh@nedomkull.com>
 import abc
 import asyncio
 import uuid
-from typing import Callable, Any, Union
+from typing import Callable, Any, Union, Optional
 
 from bleak.backends.service import BleakGATTServiceCollection
 
@@ -29,6 +29,7 @@ class BaseBleakClient(abc.ABC):
         self._notification_callbacks = {}
 
         self._timeout = kwargs.get("timeout", 2.0)
+        self._mtu: Optional[int] = None
 
     def __str__(self):
         return "{0}, {1}".format(self.__class__.__name__, self.address)
@@ -48,6 +49,16 @@ class BaseBleakClient(abc.ABC):
         await self.disconnect()
 
     # Connectivity methods
+
+    @abc.abstractmethod
+    async def get_mtu(self) -> Optional[int]:
+        """Get the exchanged MTU value in bytes.
+
+        Returns:
+            The exchanged MTU value or None on error.
+        """
+
+        raise NotImplementedError()
 
     @abc.abstractmethod
     async def set_disconnected_callback(


### PR DESCRIPTION
*** Just an idea since our `Messages` tend to be quite big and sending a `Request` in chunks of 23-1 bytes seems very not optimized :-D ***

    BlueZ does not provide an easy way to access the MTU which forces us
    to assume that it is 23 bytes in order to split our messages into
    frames with a leading fragment byte.
    
    By calling AcquireWrite [1], we can lock the current write and get a
    writable socket and the initially exchanged MTU value with the central
    in order to perform a Write Command (which we won't do as we just want
    to get the MTU value and close the socket).
    
    Note that BlueZ 5.50 relies only on AcquireWrite anyway.
    
    [1]
    https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/gatt-api.txt#n115
