### PR TITLE
Very basic Pairing Support

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -15,7 +15,7 @@ from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakError
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.bluezdbus import defs, signals, utils
-from bleak.backends.bluezdbus.discovery import discover
+from bleak.backends.bluezdbus.discovery import discover, filter_on_adapter
 from bleak.backends.bluezdbus.utils import get_device_object_path, get_managed_objects
 from bleak.backends.bluezdbus.service import BleakGATTServiceBlueZDBus
 from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -16,7 +16,7 @@ from twisted.internet.error import ReactorNotRunning
 logger = logging.getLogger(__name__)
 
 
-def _filter_on_adapter(objs, pattern="hci0"):
+def filter_on_adapter(objs, pattern="hci0"):
     for path, interfaces in objs.items():
         adapter = interfaces.get(defs.ADAPTER_INTERFACE)
         if adapter is None:
@@ -192,7 +192,7 @@ class AsyncDiscovery():
             interface=defs.OBJECT_MANAGER_INTERFACE,
             destination=defs.BLUEZ_SERVICE,
         ).asFuture(self.loop)
-        self.adapter_path, interface = _filter_on_adapter(objects,
+        self.adapter_path, interface = filter_on_adapter(objects,
                                                           self.device)
         self.cached_devices = dict(_filter_on_device(objects))
 


### PR DESCRIPTION
Add a keyword argument to enable basic pairing. This only makes sense
if the server supports only Just Works pairing without input and output.
On disconnection make sure you remove the pairing information again.