### PR TITLE
 Wait for BlueZ to resolve services even when skipping discovery

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -222,13 +222,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 "Connection to {0} was not successful!".format(self.address)
             )
 
-        if not skip_discovery:
-            # Get all services. This means making the actual connection.
-            try:
-                await self.get_services()
-            except BleakError:
-                await self._cleanup_all()
-                raise
+        # Get all services. This means making the actual connection.
+        try:
+            await self.get_services(skip_discovery=skip_discovery)
+        except BleakError:
+            await self._cleanup_all()
+            raise
 
         properties = await self._get_device_properties()
         if not properties.get("Connected"):
@@ -410,7 +409,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
     # GATT services methods
 
     @raise_on_bus_not_set
-    async def get_services(self) -> BleakGATTServiceCollection:
+    async def get_services(
+            self, skip_discovery: bool = False) -> BleakGATTServiceCollection:
         """Get all services registered for this GATT server.
 
         Returns:
@@ -434,6 +434,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         if not services_resolved:
             raise BleakError("Services discovery error")
+
+        if skip_discovery:
+            return self.services
 
         logger.debug("Get Services...")
         objs = await get_managed_objects(

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -194,7 +194,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
             if iface == is_resolved:
                 logger.info("Services resolved.")
-                self.services_resolved = True
+                self._services_resolved = True
 
         rule_id = await signals.listen_properties_changed(
             self._bus, self.loop, _services_resolved_callback


### PR DESCRIPTION
Somehow BlueZ goes crazy if we do not wait for the services to be resolved
after a connec. The discovery becomes unavailable and a exception will be
thrown at any moment when ones try to do a DBus call.

We skip the complete services discovery but still wait for BlueZ to set
the `ServicesResolved` field to true.

This commit fixes the issue but unfortunately it also seems to increase the
disconnect time from around one second to three seconds, maybe BlueZ is
cleaning more things in the background?