### PR TITLE
fix(client): Ensure that the bus is connected before pairing

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -441,6 +441,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
             Boolean regarding success of pairing.
 
         """
+        if self._bus is None:
+            self._bus = await MessageBus(
+                bus_type=BusType.SYSTEM, negotiate_unix_fd=True
+            ).connect()
+
         # See if it is already paired.
         reply = await self._bus.call(
             Message(


### PR DESCRIPTION
it's amazing no-one caught this, or is everyone else just connecting before pairing despite the documentation?