### PR TITLE
fix(client): Ensure that the bus is connected before pairing

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -441,6 +441,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
             Boolean regarding success of pairing.
 
         """
+        if self._bus is None:
+            self._bus = await MessageBus(
+                bus_type=BusType.SYSTEM, negotiate_unix_fd=True
+            ).connect()
+
         # See if it is already paired.
         reply = await self._bus.call(
             Message(


### PR DESCRIPTION
Ticket: https://proglove.atlassian.net/browse/MD2-2339

If pairing is attempted before the bus is connected, the pairing process fails due to an exception being raised.

Side note: fix raised on main repo, still pending: https://github.com/hbldh/bleak/pull/1713