### PR TITLE
Add util to check if running on a Gateway

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,10 +4,11 @@
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
-        },
-      },
-      "black-formatter.importStrategy": "fromEnvironment",
-      "isort.importStrategy": "fromEnvironment",
-      "isort.args":["--profile", "black"],
-      "flake8.importStrategy": "fromEnvironment"
+        }
+    },
+    "black-formatter.importStrategy": "fromEnvironment",
+    "isort.importStrategy": "fromEnvironment",
+    "isort.args": ["--profile", "black"],
+    "flake8.importStrategy": "fromEnvironment",
+    "editor.renderWhitespace": "trailing"
 }

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -41,6 +41,7 @@ from .utils import (
     assert_reply,
     device_path_from_characteristic_path,
     get_dbus_authenticator,
+    is_running_on_gateway,
 )
 
 logger = logging.getLogger(__name__)
@@ -256,7 +257,7 @@ class BlueZManager:
                 if uuids is not None:
                     uuids_list = uuids.value
 
-                if defs.PROGLOVE_BEACON_UUID in uuids_list:
+                if defs.PROGLOVE_BEACON_UUID in uuids_list and is_running_on_gateway():
                     # subscribe to profilter signals
                     logger.info("Subscribing to profilter signals")
                     interfaces_interface = defs.PROFILTER_INTERFACE

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-import os
+import platform
+import re
 from typing import Optional
 
 from dbus_fast.auth import AuthExternal
@@ -67,3 +68,20 @@ def get_dbus_authenticator() -> Optional[AuthExternal]:
         auth = AuthExternal(uid=uid)
 
     return auth
+
+
+def is_running_on_gateway() -> bool:
+    """
+    Determines if the code is running on a gateway device.
+
+    Proglove Gateways have a hostname that starts with "gateway-"
+    and has 5 to 6 decimal digits after the hyphen.
+
+    Returns:
+        True if running on a gateway device, False otherwise.
+    """
+    hostname = platform.node().lower()
+    cpu_arch = platform.machine().lower()
+    return re.match(r"^gateway-\d{5,6}$", hostname) is not None and cpu_arch.startswith(
+        "arm"
+    )


### PR DESCRIPTION
- if running on gateway, subscribe to profilter
- otherwise -> bluez all the way 😄 

Uses the following:
- hostname: `gateway-123456` is a valid hostname
- cpu arch: gateways are running on raspberry pi's which have armv6l (GW1) and armv7l (GWP) architectures.